### PR TITLE
Feat/rage ai endpoints

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,8 +52,11 @@ services:
       - terraform
     ports:
       - "8000:8000"
+    volumes:
+      - ./services/rage-ai/src:/app
     environment:
       - AWS_ENDPOINT_URL=http://localstack:4566
+    command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
     networks:
       - local-services
 

--- a/docs/rage-progress.md
+++ b/docs/rage-progress.md
@@ -17,14 +17,14 @@
 **2. Python AI Inference Service (Private Backend)**
 * **Description:** A specialized FastAPI service responsible for running the LLM and embedding models.
 * **Status:** 🟡 **Started**
-* **Progress:** The service directory (`services/rage-ai`), a placeholder Python file, and a `Dockerfile` have been created. The service is integrated into `docker-compose`. A placeholder `/chat` endpoint is working. The codebase is structured to follow Clean Architecture principles.
-* **Remaining Tasks:** Implement the FastAPI application logic, including the `/embeddings` and `/chat` endpoints. Integrate `llama-cpp-python` and the sentence-transformer models to provide actual AI functionality. Extract everything from `main.py` to the correct created files and directories. The files are created but are empty.
+* **Progress:** The service directory (`services/rage-ai`), a placeholder Python file, and a `Dockerfile` have been created. The service is integrated into `docker-compose`. A placeholder `/chat` endpoint is working. The codebase is structured to follow Clean Architecture principles. The `/embeddings` endpoint has been implementated successfully. 
+* **Remaining Tasks:** Implement the FastAPI application logic, including the `/embeddings` and `/chat` endpoints. Integrate `llama-cpp-python` and the sentence-transformer models to provide actual AI functionality. Extract everything from `main.py` to the correct created files and directories. The files are created but are empty. Create unit tests, linting and coverage validations to run before being able to run the service. Create integrated tests to run in CI/CD after deploy.
 
 **3. Java/Spring Boot BFF Service (Public-Facing API)**
 * **Description:** A Java 21/Spring Boot 3 service that acts as the secure public entry point (Backend for Frontend).
 * **Status:** 🟡 **Started**
 * **Progress:** The Gradle project structure (`services/rage-bff`), a placeholder `Application.java`, and a `Dockerfile` have been created. The service is integrated into `docker-compose`. The codebase is structured to follow Clean Architecture principles.
-* **Remaining Tasks:** Implement the primary REST controllers. Establish the service-to-service communication with the `rage-ai` service via the internal API Gateway. Integrate OpenAPI (`springdoc-openapi`) documentation. Extract everything from `Application.java` into the correct packages and java files created, implement the service itself. The files are created but are empty.
+* **Remaining Tasks:** Implement the primary REST controllers. Establish the service-to-service communication with the `rage-ai` service via the internal API Gateway. Integrate OpenAPI (`springdoc-openapi`) documentation. Extract everything from `Application.java` into the correct packages and java files created, implement the service itself. The files are created but are empty. Create unit tests, linting and coverage validations to run before being able to run the service. Create integrated tests to run in CI/CD after deploy.
 
 **4. API Security Layer**
 * **Description:** Secures the Java BFF using an AWS API Gateway with a built-in Cognito User Pool Authorizer.
@@ -48,8 +48,8 @@
 **7. Infrastructure as Code (IaC) & Kubernetes**
 * **Description:** Terraform and Kubernetes manifests defining the cloud infrastructure and application deployments.
 * **Status:** ✅ **In Progress**
-* **Progress:** The `iac` directory is set up with `main.tf` and `variables.tf`. A containerized Terraform environment is defined in `docker-compose` to automatically apply configurations against LocalStack. The API Gateway configuration for the `rage-bff` service is complete.
-* **Remaining Tasks:** Add the Cognito User Pool to the Terraform configuration. Define the specific AWS resources (S3, API Gateway, Lambdas, etc.) in Terraform. Create the Kubernetes manifests for each service. Create a different API gateway for the rage-ai, so it can be called independently from the BFF api gateway, with different security for each endpoint (and so that the `/chat` endpoint can be replicated on both). Use the gateway ID and uris as an output, `rage-ai`'s for the `rage-bff` configuration, and `rage-bff`'s for `rage-front`'s configuration.
+* **Progress:** The `iac` directory is set up with `main.tf` and `variables.tf`. A containerized Terraform environment is defined in `docker-compose` to automatically apply configurations against LocalStack. The API Gateway configuration for the `rage-bff` service is complete. The swagger for the `rage-ai`'s `/embeddings` and `/chat` are defined and are being configured in the Localstack's API Gateway service.
+* **Remaining Tasks:** Add the Cognito User Pool to the Terraform configuration. Define the specific AWS resources (S3, API Gateway, Lambdas, etc.) in Terraform. Create the Kubernetes manifests for each service. Create a different API gateway for the rage-bff, so it can be called independently from the rage-ai gateway, with different security for each endpoint (and so that the `/chat` endpoint can be replicated on both). Use the gateway ID and uris as an output, `rage-ai`'s for the `rage-bff` configuration, and `rage-bff`'s for `rage-front`'s configuration.
 
 **8. CI/CD Pipeline**
 * **Description:** A GitHub Actions workflow to automate building, testing, and infrastructure validation.

--- a/iac/api-definitions/rage-ai.yaml.tftpl
+++ b/iac/api-definitions/rage-ai.yaml.tftpl
@@ -27,7 +27,41 @@ paths:
       x-amazon-apigateway-integration:
         type: "http_proxy"
         httpMethod: "POST"
-        uri: "${backend_uri}"
+        uri: "${backend_uri}/chat"
         passthroughBehavior: "when_no_match"
         connectionType: "VPC_LINK" 
-        
+  /embeddings:
+    post:
+      summary: "Requests an embedding using the server model"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                text:
+                  type: string
+                  example: "How do I find the secret entrance in the wall in Full Throttle?"
+      responses:
+        "200":
+          description: "Successful embedding"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  embeddings:
+                    type: array
+                    items:
+                      type: number
+                    example: "[0.019174499437212944,-0.045545537024736404,-0.0149582140147686,-0.05264071747660637,-0.03069937787950039,0.0013246954185888171]"
+                  model:
+                    type: string
+                    example: "Qwen/Qwen3-Embedding-0.6B"
+      x-amazon-apigateway-integration:
+        type: "http_proxy"
+        httpMethod: "POST"
+        uri: "${backend_uri}/embeddings"
+        passthroughBehavior: "when_no_match"
+        connectionType: "VPC_LINK" 

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -12,7 +12,7 @@ resource "aws_api_gateway_rest_api" "rage_api" {
   description = "The main API Gateway for the RAGE project"
 
   body = templatefile("${path.module}/api-definitions/rage-ai.yaml.tftpl", {
-    backend_uri = "http://rage-ai:8000/chat"
+    backend_uri = "http://rage-ai:8000"
   })
 }
 
@@ -21,7 +21,7 @@ resource "aws_api_gateway_deployment" "api_deployment" {
 
   triggers = {
     redeployment = sha1(templatefile("${path.module}/api-definitions/rage-ai.yaml.tftpl", {
-      backend_uri = "http://rage-ai:8000/chat"
+      backend_uri = "http://rage-ai:8000"
     }))
   }
 

--- a/services/rage-ai/src/api/v1/endpoints/embeddings.py
+++ b/services/rage-ai/src/api/v1/endpoints/embeddings.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends
 from core.domain.entities import EmbeddingRequest, EmbeddingResponse
 from infra.adapters.llm_adapter import LLMAdapter
 from api.v1.endpoints.dependencies import get_llm_adapter
+import datetime
 
 # Create a FastAPI router for embeddings-related endpoints.
 embeddings_router = APIRouter()
@@ -12,5 +13,7 @@ async def create_embeddings(request_body: EmbeddingRequest, llm_adapter: LLMAdap
     Generates and returns embeddings for the provided text using the embedding model.
     """
     embeddings = llm_adapter.get_embeddings(request_body.text)
-    
-    return EmbeddingResponse(embeddings=embeddings, model="Qwen/Qwen3-Embedding-0.6B")
+    timestamp = datetime.datetime.now().isoformat()
+    print(f"[{timestamp}] Received embeddings text: '{request_body.text}'")
+
+    return EmbeddingResponse(embeddings=embeddings, model=llm_adapter.model)

--- a/services/rage-ai/src/infra/adapters/llm_adapter.py
+++ b/services/rage-ai/src/infra/adapters/llm_adapter.py
@@ -13,9 +13,9 @@ class LLMAdapter:
         Initializes the SentenceTransformer model.
         """
         try:
-            model = 'Qwen/Qwen3-Embedding-0.6B'
-            print(f"Loading SentenceTransformer model ({model})")
-            self.embedding_model = SentenceTransformer(model)
+            self.model = 'Qwen/Qwen3-Embedding-0.6B'
+            print(f"Loading SentenceTransformer model ({self.model})")
+            self.embedding_model = SentenceTransformer(self.model)
             print("Successfully loaded SentenceTransformer model.")
         except Exception as e:
             print(f"Error loading SentenceTransformer model: {e}")
@@ -47,7 +47,6 @@ class LLMAdapter:
         Returns:
             The generated chat response.
         """
-        # In your final implementation, you would use llama-cpp-python here.
-        # For now, we'll return a static, mock response.
+        # missing implementation
         print(f"Generating chat response for prompt: '{prompt}'")
         return f"Hello from the FastAPI server! Your prompt was: {prompt}"


### PR DESCRIPTION
Using the Qwen/Qwen3-Embedding-0.6B model, it takes 3 minutes on my machine to get the rage-ai service running. Just be patient and wait until docker-compose logs tell you the service is up, then both /chat and /embeddings work fine.